### PR TITLE
Also return 'dateOrMoment' when empty string (#3)

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -70,6 +70,7 @@ export function normalizeDate(dateOrMoment) {
   if (
     dateOrMoment === undefined ||
     dateOrMoment === null ||
+    dateOrMoment === '' ||
     dateOrMoment instanceof Date
   ) {
     return dateOrMoment;


### PR DESCRIPTION
- prevent 'dateOrMoment.toDate' is not a function